### PR TITLE
feat(dev-server): configure custom port to avoid permission issues

### DIFF
--- a/Restaurante.Frontend/Restaurante.AngularJS/package.json
+++ b/Restaurante.Frontend/Restaurante.AngularJS/package.json
@@ -7,8 +7,8 @@
   "type": "module",
   "main": "./dist/bundle.js",
   "scripts": {
-    "start": "webpack serve --mode development --open",
-    "cdev": "webpack serve --mode development",
+    "start": "webpack serve --mode development --port 4200 --open",
+    "cdev": "webpack serve --mode development --port 4200",
     "watch": "webpack --watch --mode development",
     "build": "webpack --mode production"
   },


### PR DESCRIPTION
Updated webpack-dev-server scripts to run on port 4200 instead of default privileged ports.

This prevents EACCES permission errors when attempting to bind to port 443 on Unix-based systems without elevated privileges.

Changes:

* Added --port 4200 to start and cdev scripts
* Ensures local development runs without requiring sudo

Notes:

* Keeps development environment aligned with common frontend defaults (e.g., Angular CLI)
* Avoids conflicts with HTTPS/SSL reserved ports