### PR TITLE
docs: restructure READMEs to reflect Nx monorepo architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,54 @@
-# Proyecto Restaurante - Ideas.
-- La idea es que cada usuario tenga un rol - Listo.
-- Segun el rol el tipo de tarea que puede hacer.
-- Implementar WebSockets para actualizar estados del pedido.
-- Implementar WebSockets para comunicarse con el soporte.
-- Comunicacion con el equipo mediante WebSockets
-- Implementar rol de soporte o asignar alguno.
-- Implementar mapas para la localizacion cliente/restaurante
-- Asignar medios de pago
-- Logica medios de pago devolucion etc...
-- Actualmente puede utilizar SQLite, la idea es implementar SQL Server.
-- Tambien utilizar para algunas aplicaciones NHibernate ORM aparte de Entity Framework.
-- La idea seria aplicar en algunos casos microservicios.
-- Hacer una interfaz grafica con React
-- Hacer una interfaz grafica con Angular
-- Hacer una interfaz grafica con AngularJS
+# Proyecto Restaurante
 
-# Accounts
-* cliente@restaurante.com:123456aA$
-* delivery@restaurante.com:123456aA$
-* recepcionista@restaurante.com:123456aA$
-* cocinero@restaurante.com:123456aA$
-* administrador@restaurante.com:123456aA$
+Proyecto fullstack para gestion de restaurante con backend .NET y frontend en monorepo usando Nx.
+
+## Frontend (Monorepo Nx)
+
+El frontend esta organizado en un monorepo con Nx para centralizar apps, compartir codigo y ejecutar tareas de forma consistente.
+
+- `apps/legacy-angularjs`: aplicacion existente basada en AngularJS.
+- `apps/restaurante-v2`: nueva aplicacion frontend basada en Angular.
+- `libs/shared/shell`: libreria compartida para logica reutilizable.
+
+### Comunicacion entre aplicaciones
+
+La integracion entre AngularJS y Angular se maneja desde el mismo workspace. El estado compartido entre `legacy-angularjs` y `restaurante-v2` se va a centralizar con Redux para desacoplar la comunicacion y facilitar la migracion progresiva.
+
+## Tecnologias
+
+- Nx (monorepo, grafo de dependencias, ejecucion de tareas, cacheo)
+- Angular (nueva aplicacion `restaurante-v2`)
+- AngularJS (aplicacion legacy `legacy-angularjs`)
+- Redux (estado compartido entre ambas aplicaciones frontend)
+- .NET / C# (backend)
+- WebSockets (actualizacion de estados y comunicacion en tiempo real)
+- SQLite (actual) y SQL Server (objetivo)
+- Entity Framework y NHibernate (segun modulo/caso de uso)
+
+## Comandos utiles del frontend
+
+```sh
+cd Restaurante.Frontend
+pnpm nx show projects
+pnpm nx graph
+pnpm nx run <project>:build
+pnpm nx run <project>:serve
+```
+
+## Ideas y roadmap
+
+- Segun el rol, definir el tipo de tarea que cada usuario puede hacer.
+- Implementar WebSockets para actualizar estados del pedido.
+- Implementar WebSockets para comunicacion con soporte y equipo interno.
+- Implementar rol de soporte o reasignar uno existente.
+- Implementar mapas para localizacion cliente/restaurante.
+- Asignar y consolidar medios de pago y logica de devolucion.
+- Evaluar microservicios en modulos que lo requieran.
+
+## Accounts de prueba
+
+- cliente@restaurante.com:123456aA$
+- delivery@restaurante.com:123456aA$
+- recepcionista@restaurante.com:123456aA$
+- cocinero@restaurante.com:123456aA$
+- administrador@restaurante.com:123456aA$

--- a/Restaurante.Frontend/README.md
+++ b/Restaurante.Frontend/README.md
@@ -1,105 +1,37 @@
-# New Nx Repository
+# Restaurante Frontend
 
-<a alt="Nx logo" href="https://nx.dev" target="_blank" rel="noreferrer"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-logo.png" width="45"></a>
+Repositorio frontend del sistema de restaurante organizado como un monorepo con Nx. La idea es centralizar el desarrollo de las dos aplicaciones del proyecto, compartir código donde tenga sentido y mantener tareas, dependencias y builds coordinados desde un solo workspace.
 
-✨ Your new, shiny [Nx workspace](https://nx.dev) is ready ✨.
+## Arquitectura
 
-[Learn more about this workspace setup and its capabilities](https://nx.dev/nx-api/js?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) or run `npx nx graph` to visually explore what was created. Now, let's get you up to speed!
-## Try the full Nx platform
-🚀 If you haven't connected to Nx Cloud yet, [complete your setup here](https://cloud.nx.app/setup/connect-workspace/guide). Get faster builds with remote caching, distributed task execution, and self-healing CI. [See how your workspace can benefit](#nx-cloud).
-## Generate a library
+El workspace está dividido en aplicaciones y librerías compartidas:
 
-```sh
-npx nx g @nx/js:lib packages/pkg1 --publishable --importPath=@my-org/pkg1
-```
+- `apps/legacy-angularjs`: aplicación existente basada en AngularJS.
+- `apps/restaurante-v2`: nueva aplicación frontend basada en Angular.
+- `libs/shared/shell`: librería compartida para lógica reutilizable entre las aplicaciones.
 
-## Run tasks
+Nx se usa para administrar el monorepo, resolver dependencias entre proyectos y ejecutar tareas de forma consistente con `pnpm nx`.
 
-To build the library use:
+## Estado de la comunicación entre apps
 
-```sh
-npx nx build pkg1
-```
+La comunicación entre `legacy-angularjs` y `restaurante-v2` se va a centralizar con Redux. Esto permitirá manejar estado compartido de forma predecible, desacoplar el intercambio de datos entre AngularJS y Angular, y dejar una base más ordenada para evolucionar la migración hacia la nueva versión.
 
-To run any task with Nx use:
+## Convenciones de trabajo
 
-```sh
-npx nx <target> <project-name>
-```
+- Cada app mantiene su propia responsabilidad de UI y navegación, aunque ambas conviven y se integran durante la transición entre AngularJS y Angular.
+- La lógica compartida debe vivir en `libs/` para evitar duplicación.
+- El estado global y los eventos compartidos entre las dos aplicaciones se resolverán con Redux.
+- Las tareas del workspace deben ejecutarse con Nx para aprovechar cacheo, dependencias y consistencia entre proyectos.
 
-These targets are either [inferred automatically](https://nx.dev/concepts/inferred-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) or defined in the `project.json` or `package.json` files.
-
-[More about running tasks in the docs &raquo;](https://nx.dev/features/run-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-## Versioning and releasing
-
-To version and release the library use
-
-```
-npx nx release
-```
-
-Pass `--dry-run` to see what would happen without actually releasing the library.
-
-[Learn more about Nx release &raquo;](https://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-## Keep TypeScript project references up to date
-
-Nx automatically updates TypeScript [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) in `tsconfig.json` files to ensure they remain accurate based on your project dependencies (`import` or `require` statements). This sync is automatically done when running tasks such as `build` or `typecheck`, which require updated references to function correctly.
-
-To manually trigger the process to sync the project graph dependencies information to the TypeScript project references, run the following command:
+## Comandos útiles
 
 ```sh
-npx nx sync
+pnpm nx show projects
+pnpm nx graph
+pnpm nx run <project>:build
+pnpm nx run <project>:serve
 ```
 
-You can enforce that the TypeScript project references are always in the correct state when running in CI by adding a step to your CI job configuration that runs the following command:
+## Notas
 
-```sh
-npx nx sync:check
-```
-
-[Learn more about nx sync](https://nx.dev/reference/nx-commands#sync)
-
-## Nx Cloud
-
-Nx Cloud ensures a [fast and scalable CI](https://nx.dev/ci/intro/why-nx-cloud?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) pipeline. It includes features such as:
-
-- [Remote caching](https://nx.dev/ci/features/remote-cache?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [Task distribution across multiple machines](https://nx.dev/ci/features/distribute-task-execution?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [Automated e2e test splitting](https://nx.dev/ci/features/split-e2e-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [Task flakiness detection and rerunning](https://nx.dev/ci/features/flaky-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-### Set up CI (non-Github Actions CI)
-
-**Note:** This is only required if your CI provider is not GitHub Actions.
-
-Use the following command to configure a CI workflow for your workspace:
-
-```sh
-npx nx g ci-workflow
-```
-
-[Learn more about Nx on CI](https://nx.dev/ci/intro/ci-with-nx#ready-get-started-with-your-provider?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-## Install Nx Console
-
-Nx Console is an editor extension that enriches your developer experience. It lets you run tasks, generate code, and improves code autocompletion in your IDE. It is available for VSCode and IntelliJ.
-
-[Install Nx Console &raquo;](https://nx.dev/getting-started/editor-setup?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-## Useful links
-
-Learn more:
-
-- [Learn more about this workspace setup](https://nx.dev/nx-api/js?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [Learn about Nx on CI](https://nx.dev/ci/intro/ci-with-nx?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [Releasing Packages with Nx release](https://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [What are Nx plugins?](https://nx.dev/concepts/nx-plugins?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-And join the Nx community:
-
-- [Discord](https://go.nx.dev/community)
-- [Follow us on X](https://twitter.com/nxdevtools) or [LinkedIn](https://www.linkedin.com/company/nrwl)
-- [Our Youtube channel](https://www.youtube.com/@nxdevtools)
-- [Our blog](https://nx.dev/blog?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+Este README describe la estructura general actual del workspace y la dirección funcional del frontend. A medida que avance la implementación de Redux y la integración entre las dos aplicaciones, se pueden agregar ejemplos de estado compartido, flujos y convenciones de slices o stores.

--- a/license.md
+++ b/license.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Restaurante
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
- Update root README with project overview, tech stack, and roadmap.
- Replace generic Nx boilerplate in Restaurante.Frontend with project-specific architecture details.
- Document migration strategy from AngularJS to Angular v2 using Redux.
- Add MIT License file.
- Update test account credentials and useful Nx commands.